### PR TITLE
Remove group permission

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,7 @@
     "require": {
         "drupal/jwt": "^2.0",
         "drupal/group": "^3.0",
-        "drupal/groupmedia": "^4.0@alpha",
-        "drupal/group_permissions":"^2.0@alpha"
+        "drupal/groupmedia": "^4.0@alpha"
     },
     "authors": [
         {

--- a/private_files_adapter.info.yml
+++ b/private_files_adapter.info.yml
@@ -9,4 +9,3 @@ dependencies:
   - jwt_auth_consumer
   - group
   - groupmedia
-  - group_permissions


### PR DESCRIPTION
The [Group Permission](https://www.drupal.org/project/group_permissions) has ongoing issues with the new version 2.0 , and 3.0 of Group module , so we're removing it as dependency.

Related issues: 
* https://www.drupal.org/project/group_permissions/issues/3368882
* https://www.drupal.org/project/group_permissions/issues/3327680 