### PR TITLE
fix: change theme and asserting status code

### DIFF
--- a/tests/src/Functional/LoadTest.php
+++ b/tests/src/Functional/LoadTest.php
@@ -4,12 +4,15 @@ namespace Drupal\Tests\private_files_adapter\Functional;
 
 use Drupal\Core\Url;
 use Drupal\Tests\BrowserTestBase;
+use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
+
 
 /**
  * Simple test to ensure that main page loads with module enabled.
- *
- * @group private_files_adapter
- */
+*
+* @group private_files_adapter
+*/
+#[RunTestsInSeparateProcesses]
 class LoadTest extends BrowserTestBase {
 
   /**

--- a/tests/src/Functional/LoadTest.php
+++ b/tests/src/Functional/LoadTest.php
@@ -6,7 +6,6 @@ use Drupal\Core\Url;
 use Drupal\Tests\BrowserTestBase;
 use PHPUnit\Framework\Attributes\RunTestsInSeparateProcesses;
 
-
 /**
  * Simple test to ensure that main page loads with module enabled.
 *

--- a/tests/src/Functional/LoadTest.php
+++ b/tests/src/Functional/LoadTest.php
@@ -26,7 +26,7 @@ class LoadTest extends BrowserTestBase {
    *
    * @var string
    */
-  protected $defaultTheme = 'stable';
+  protected $defaultTheme = 'stark';
 
   /**
    * A user with permission to administer site configuration.
@@ -49,7 +49,7 @@ class LoadTest extends BrowserTestBase {
    */
   public function testLoad() {
     $this->drupalGet(Url::fromRoute('<front>'));
-    $this->assertSession()->statusMessageContains('200');
+    $this->assertSession()->statusCodeEquals(200);
   }
 
 }


### PR DESCRIPTION
# Description
This PR makes minor adjustments to the `LoadTest` functional test to fix PHPUnit errors.

# Changes
- Updates the theme used in `LoadTest` from `stable` to `stark`, since `stable` is not known.
- Updates the test assertion to use `statusCodeEquals(200)` instead of checking for a status message containing `200` string.
- Add `#[RunTestsInSeparateProcesses]` to follow the new changes in Drupal ([Reference](https://www.drupal.org/node/3548485)).